### PR TITLE
[codea, codeb, gesamt] changed how the program is called via execlp

### DIFF
--- a/abgabe/codea/test_suite_codea.c
+++ b/abgabe/codea/test_suite_codea.c
@@ -159,7 +159,7 @@ int main_test_loop(char * input_codea, char * input_testfile, int fail_case) {
         return 1;
     }
 
-}    
+}
 
 int compile(int type) {
 
@@ -177,7 +177,7 @@ int compile(int type) {
             } else if (type == 2) {
                 execlp("gcc", "gcc", "-o", "test", "test.o", "test_asm.o", NULL);
             } else if (type == 3) {
-                execlp("test", "test", NULL);
+                execlp("./test", "test", NULL);
             }
 
             exit(-1);

--- a/abgabe/codeb/test_suite_codeb.c
+++ b/abgabe/codeb/test_suite_codeb.c
@@ -177,7 +177,7 @@ int compile(int type) {
             } else if (type == 2) {
                 execlp("gcc", "gcc", "-o", "test", "test.o", "test_asm.o", NULL);
             } else if (type == 3) {
-                execlp("test", "test", NULL);
+                execlp("./test", "test", NULL);
             }
 
             exit(-1);

--- a/abgabe/gesamt/test_suite_gesamt.c
+++ b/abgabe/gesamt/test_suite_gesamt.c
@@ -177,7 +177,7 @@ int compile(int type) {
             } else if (type == 2) {
                 execlp("gcc", "gcc", "-o", "test", "test.o", "test_asm.o", NULL);
             } else if (type == 3) {
-                execlp("test", "test", NULL);
+                execlp("./test", "test", NULL);
             }
 
             exit(-1);


### PR DESCRIPTION
Fixed a bug where the compiled program (test) is not called correctly and therefore the test cases fail.