### PR TITLE
pipe the error-messages into /dev/null

### DIFF
--- a/abgabe/codea/run.sh
+++ b/abgabe/codea/run.sh
@@ -1,9 +1,9 @@
 #/bin/bash
 
 make -C ../../../abgabe/codea clean
-gcc test_suite_codea.c -o test_suite_codea
+gcc test_suite_codea.c -o test_suite_codea 2> /dev/null
 make -C ../../../abgabe/codea
-./test_suite_codea
+./test_suite_codea  2> /dev/null
 make -C ../../../abgabe/codea clean
 
 rm -f test_suite_codea

--- a/abgabe/codeb/run.sh
+++ b/abgabe/codeb/run.sh
@@ -1,9 +1,9 @@
 #/bin/bash
 
 make -C ../../../abgabe/codeb clean
-gcc test_suite_codeb.c -o test_suite_codeb
+gcc test_suite_codeb.c -o test_suite_codeb 2> /dev/null
 make -C ../../../abgabe/codeb
-./test_suite_codeb
+./test_suite_codeb 2> /dev/null
 make -C ../../../abgabe/codeb clean
 
 rm -f test_suite_codeb

--- a/abgabe/gesamt/run.sh
+++ b/abgabe/gesamt/run.sh
@@ -1,9 +1,9 @@
 #/bin/bash
 
 make -C ../../../abgabe/gesamt clean
-gcc test_suite_gesamt.c -o test_suite_gesamt
+gcc test_suite_gesamt.c -o test_suite_gesamt 2> /dev/null
 make -C ../../../abgabe/gesamt
-./test_suite_gesamt
+./test_suite_gesamt 2> /dev/null
 make -C ../../../abgabe/gesamt clean
 
 rm -f test_suite_gesamt


### PR DESCRIPTION
the report throws a lot of implicit function declaration errors. This does not look nice in the report, so we could just pip it to /dev/null. This will generate some nicer console output 